### PR TITLE
Test result parsing and notification updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       "devDependencies": {
         "cypress": "^6.7.0",
         "fast-glob": "^3.2.5",
+        "jest-junit": "^12.0.0",
         "junitxml-to-javascript": "^1.1.4",
         "node-fetch": "^2.6.1"
       }
@@ -11776,6 +11777,63 @@
         "node": ">=8"
       }
     },
+    "node_modules/jest-junit": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-12.0.0.tgz",
+      "integrity": "sha512-+8K35LlboWiPuCnXSyiid7rFdxNlpCWWM20WEYe6IZH6psfUWKZmSpSRQ5tk0C0cBeDsvsnIzcef5mYhyJsbug==",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^5.2.0",
+        "uuid": "^3.3.3",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/jest-junit/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jest-junit/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-junit/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jest-junit/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/jest-leak-detector": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz",
@@ -22541,6 +22599,12 @@
         }
       }
     },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
+    },
     "node_modules/xml-name-validator": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
@@ -31798,6 +31862,47 @@
         }
       }
     },
+    "jest-junit": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-12.0.0.tgz",
+      "integrity": "sha512-+8K35LlboWiPuCnXSyiid7rFdxNlpCWWM20WEYe6IZH6psfUWKZmSpSRQ5tk0C0cBeDsvsnIzcef5mYhyJsbug==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^5.2.0",
+        "uuid": "^3.3.3",
+        "xml": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
+      }
+    },
     "jest-leak-detector": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz",
@@ -40296,6 +40401,12 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
       "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
       "requires": {}
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --ci --reporters=default --reporters=jest-junit",
     "eject": "react-scripts eject",
     "cypress": "./node_modules/.bin/cypress open"
   },
@@ -39,7 +39,13 @@
   "devDependencies": {
     "cypress": "^6.7.0",
     "fast-glob": "^3.2.5",
+    "jest-junit": "^12.0.0",
     "junitxml-to-javascript": "^1.1.4",
     "node-fetch": "^2.6.1"
+  },
+  "jest-junit": {
+    "suiteNameTemplate": "{filename}",
+    "classNameTemplate": "{filename}",
+    "outputDirectory": "reports/junit"
   }
 }

--- a/scripts/notifySlack.js
+++ b/scripts/notifySlack.js
@@ -8,9 +8,10 @@ const username =
 
 const prUrl = process.env["CIRCLE_PULL_REQUEST"];
 const circleJobUrl = process.env["CIRCLE_BUILD_URL"];
+const testType = process.env["CIRCLE_JOB"];
 
 const notifyPass = async (numSuites) => {
-  const msg = `🎉 ✅ Yay! *${username}* passed all ${numSuites} tests in ${repoName}!`;
+  const msg = `🎉 ✅ Yay! *${username}* passed all ${numSuites} ${testType} tests in ${repoName}!`;
   console.log(msg);
   await postToSlack(webhookUrl, msg);
 };
@@ -18,7 +19,7 @@ const notifyPass = async (numSuites) => {
 const notifyFail = async ({ numSuites, passedSuites, failedSuites }) => {
   const msg = `😿 🚫 *${username}* passed ${
     passedSuites.length
-  } / ${numSuites} tests for ${repoName}
+  } / ${numSuites} ${testType} tests for ${repoName}
 Failing tests:
 
 • ${failedSuites.join(" \n • ")}

--- a/scripts/parseJunit.js
+++ b/scripts/parseJunit.js
@@ -22,7 +22,7 @@ const failedSuites = [];
 const passed = (suite) => suite.succeeded === suite.tests;
 
 const parseAllFiles = async () => {
-  const glob = __dirname + "/../reports/junit/junit-*.xml";
+  const glob = __dirname + "/../reports/junit/junit*.xml";
   const fileNames = fg.sync(glob);
   numSuites = fileNames.length;
 
@@ -36,7 +36,9 @@ const parseAllFiles = async () => {
       passedSuites.push(testsuites[0].name);
     } else {
       let failed = testsuites.filter((ts) => !passed(ts));
-      failedSuites.push(failed[0].name);
+      failed.forEach((ts) => {
+        failedSuites.push(ts.name);
+      });
     }
   }
 


### PR DESCRIPTION
Additional fixes needed to notify and parse jest test results in Circle:
- add `reporters` flags to test scripts
- add `jest-junit` as a dev dependency
- add `jest-junit` configuration to `package.json`

These changes are now in the template but that's too late for this lab.
- Look for files named `junit*.xml` (without the dash so that we find jest test files, which are saved as a single `junit.xml` file)
- Capture and print the names of all failed suites (not just the first)

This change is not in the template and is specific for random labs (like this one) that run both jest and cypress tests.
- Output the type of test to slack (jest or cypress)